### PR TITLE
Added ability to change the idle emote to follow cursor emote and back on right mouse click

### DIFF
--- a/Desktop_Gremlin/SpriteSheet.xaml
+++ b/Desktop_Gremlin/SpriteSheet.xaml
@@ -11,7 +11,7 @@
         Background="Transparent"
         Topmost="True"
         ResizeMode="NoResize"  BorderThickness="0" BorderBrush="Black" KeyDown="Window_KeyDown" KeyUp="Window_KeyUp">
-    <Grid MouseLeftButtonDown="Canvas_MouseLeftButtonDown" Margin="0,0,10,10" >
+    <Grid MouseLeftButtonDown="Canvas_MouseLeftButtonDown" MouseRightButtonDown="Canvas_MouseRightButtonDown" Margin="0,0,10,10" >
         <Image Name="SpriteImage"
            Width="160" Height="162"
            HorizontalAlignment="Left"

--- a/Desktop_Gremlin/SpriteSheet.xaml.cs
+++ b/Desktop_Gremlin/SpriteSheet.xaml.cs
@@ -176,6 +176,19 @@ namespace Desktop_Gremlin
                     }
                 }
 
+                // This plays EMOTE2 indefinetely while IS_EMOTING2 == true and interrupts it on other actions
+                if (IS_EMOTING2)
+                {
+                    if (IS_WALKING || IS_DRAGGING || FOLLOW_CURSOR)
+                    {
+                        IS_EMOTING2 = false;
+                    }
+                    else
+                    {
+                        CURRENT_EMOTE_2 = PlayAnimationFrame(EMOTE2_SHEET, CURRENT_EMOTE_2, EMOTE2_FRAME_COUNT);
+                    }
+                }
+
                 if (!IS_DRAGGING && !IS_WALKING && !IS_EMOTING1 && !FOLLOW_CURSOR && !IS_EMOTING2)
                 {
                     CURRENT_IDLE_FRAME = PlayAnimationFrame(IDLE_SHEET, CURRENT_IDLE_FRAME, IDLE_FRAME_COUNT);
@@ -223,8 +236,8 @@ namespace Desktop_Gremlin
                         }
                     }
                     else
-                    {                       
-                        CURRENT_EMOTE_2 = PlayAnimationFrame(EMOTE2_SHEET, CURRENT_EMOTE_2, EMOTE2_FRAME_COUNT);                       
+                    {
+                        CURRENT_EMOTE_2 = PlayAnimationFrame(EMOTE2_SHEET, CURRENT_EMOTE_2, EMOTE2_FRAME_COUNT);
                     }
                 }
                 else if (IS_WALKING)
@@ -274,10 +287,26 @@ namespace Desktop_Gremlin
             DragMove();
 
             FOLLOW_CURSOR = !FOLLOW_CURSOR;
-            IS_EMOTING2 = !IS_EMOTING2;
+
+            // A hack to make sure IDLE animation plays after FOLLOW_CURSOR behaivour is turned off
+            if (!FOLLOW_CURSOR)
+            {
+                IS_EMOTING2 = false;
+            }
+            else
+            {
+                IS_EMOTING2 = !IS_EMOTING2;
+            }
 
             IS_DRAGGING = false;
         }
+
+        // Simply toggling on RMB click to signal if we want the EMOTE2 to play
+        private void Canvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            IS_EMOTING2 = !IS_EMOTING2;
+        }
+
         private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
             if (e.Key == Key.Left)


### PR DESCRIPTION
I liked the dance Agnes does when standing still while in cursor following mode, so I grabbed a can of beer and did this. 
My testing showed no problems with other functionality, works as it did before. 
If you have different plans for right click, I propose changing RMB click to a specific button, but in the end it's up to you.