### PR TITLE
Fix ConfigManager for different cultures

### DIFF
--- a/Desktop_Gremlin/ConfigManager.cs
+++ b/Desktop_Gremlin/ConfigManager.cs
@@ -49,7 +49,7 @@ public static class ConfigManager
                     }
                 case "SPRITE_FRAMERATE":
                     {
-                        if (int.TryParse(value, out int intValue))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int intValue))
                         {
                             Settings.FrameRate = intValue;
                         }
@@ -57,7 +57,7 @@ public static class ConfigManager
                     }
                 case "FOLLOW_RADIUS":
                     {
-                        if (double.TryParse(value, out double intValue))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double intValue))
                         {
                             Settings.FollowRadius = intValue;
                         }
@@ -65,7 +65,7 @@ public static class ConfigManager
                     }
                 case "MAX_INTERVAL":
                     {
-                        if (int.TryParse(value, out int intValue))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int intValue))
                         {
                             Settings.RandomMaxInterval = intValue;
                         }
@@ -73,7 +73,7 @@ public static class ConfigManager
                     break;
                 case "MIN_INTERVAL":
                     {
-                        if (int.TryParse(value, out int intValue))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int intValue))
                         {
                             Settings.RandomMinInterval = intValue;
                         }
@@ -81,7 +81,7 @@ public static class ConfigManager
                     break;
                 case "RANDOM_MOVE_DISTANCE":
                     {
-                        if (int.TryParse(value, out int intValue))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int intValue))
                         {
                             Settings.MoveDistance = intValue;
                         }
@@ -105,7 +105,7 @@ public static class ConfigManager
                     break;
                 case "SLEEP_TIME":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.SleepTime = Value;
                         }
@@ -121,7 +121,7 @@ public static class ConfigManager
                     break;
                 case "AMMO":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.Ammo = Value;
                         }
@@ -146,7 +146,7 @@ public static class ConfigManager
                     break;
                 case "SPRITE_SCALE":
                     {
-                        if (double.TryParse(value, out double Value))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double Value))
                         {
                             Settings.SpriteSize = Value;
                         }
@@ -170,7 +170,7 @@ public static class ConfigManager
                     break;
                 case "MAX_ACCELERATION":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.MaxItemAcceleration = Value;
                         }
@@ -178,7 +178,7 @@ public static class ConfigManager
                     break;
                 case "FOLLOW_ACCELERATION":
                     {
-                        if (double.TryParse(value, out double Value))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double Value))
                         {
                             Settings.ItemAcceleration = Value;
                         }
@@ -186,7 +186,7 @@ public static class ConfigManager
                     break;
                 case "CURRENT_ACCELERATION":
                     {
-                        if (double.TryParse(value, out double Value))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double Value))
                         {
                             Settings.ItemAcceleration = Value;
                         }
@@ -194,7 +194,7 @@ public static class ConfigManager
                     break;
                 case "MAX_EATING_SIZE":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.FoodItemGetSize = Value;
                         }
@@ -202,7 +202,7 @@ public static class ConfigManager
                     break;
                 case "ITEM_WIDTH":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.ItemWidth = Value;
                         }
@@ -210,7 +210,7 @@ public static class ConfigManager
                     break;
                 case "ITEM_HEIGHT":
                     {
-                        if (int.TryParse(value, out int Value))
+                        if (int.TryParse(value, CultureInfo.InvariantCulture, out int Value))
                         {
                             Settings.ItemHeight = Value;
                         }
@@ -218,7 +218,7 @@ public static class ConfigManager
                     break;
                 case "COMPANIONS_SCALE":
                     {
-                        if (double.TryParse(value, out double Value))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double Value))
                         {
                             Settings.CompanionScale = Value;
                         }
@@ -250,7 +250,7 @@ public static class ConfigManager
                     break;
                 case "VOLUME_LEVEL":
                     {
-                        if (double.TryParse(value, out double Value))
+                        if (double.TryParse(value, CultureInfo.InvariantCulture, out double Value))
                         {
                             Settings.VolumeLevel = Value;
                         }
@@ -291,7 +291,7 @@ public static class ConfigManager
             string key = parts[0].Trim();
             string value = parts[1].Trim();
 
-            if (!int.TryParse(value, out int intValue))
+            if (!int.TryParse(value, CultureInfo.InvariantCulture, out int intValue))
             {
                 continue;
             }

--- a/Desktop_Gremlin/ConfigManager.cs
+++ b/Desktop_Gremlin/ConfigManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;


### PR DESCRIPTION
I figured out why some people had issues with sprites appearing bigger than expected and sometimes even out of the visible space. it's because of the different language.

For some culture settings the comma is used instead of the dot, and the decimal numbers from the settings were misinterpreted.
for example, 0.50 could result in 50.

To avoid this, "TryParse" should be used with "CultureInfo.InvariantCulture".

I also added that to int.TryParse, even if probably doesn't really makes a difference here.

This should fix https://github.com/KurtVelasco/Desktop_Gremlin/issues/42, https://github.com/KurtVelasco/Desktop_Gremlin/issues/36, https://github.com/KurtVelasco/Desktop_Gremlin/issues/34